### PR TITLE
Push after the docker build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,13 +16,12 @@ jobs:
         docker-suffix:  ['edge', 'preview', 'latest']
     steps:
       - uses: actions/checkout@v2
-      - name: build the docker
-        run: |
-          docker build -f Dockerfile.${{ matrix.docker-suffix }} -t redismod:${{ matrix.docker-suffix }} .
       - name: Log in to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_REDISFAB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_REDISFAB_TOKEN }}
-      - name: docker push
-        run: docker push redislabs/redismod:${{matrix.docker-suffix}}
+      - name: build the docker
+        run: |
+          docker build -f Dockerfile.${{ matrix.docker-suffix }} -t redismod:${{ matrix.docker-suffix }} .
+          docker push redislabs/redismod:${{matrix.docker-suffix}}


### PR DESCRIPTION
Due to how github actions work, the image is not cached between steps. This means, for our use case we should push, immediately after the build